### PR TITLE
feature: カレンダーを表示できるように

### DIFF
--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -27,7 +27,6 @@ function main() {
   printCalendarBody(
     specified_date.startOf("M"),
     specified_date.endOf("M"),
-    specified_date.isSame(now, "month"),
     now,
   );
 }
@@ -37,7 +36,7 @@ function printCalendarHeader(month, year) {
   console.log(`日 月 火 水 木 金 土`);
 }
 
-function printCalendarBody(first_date, last_date, is_this_month, now) {
+function printCalendarBody(first_date, last_date, now) {
   for (let i = 0; i < Number(first_date.format("d")); i++) {
     process.stdout.write("   ");
   }
@@ -45,16 +44,7 @@ function printCalendarBody(first_date, last_date, is_this_month, now) {
   for (let i = 1; i <= Number(last_date.format("D")); i++) {
     const current_date = first_date.date(i);
 
-    if (is_this_month) {
-      process.stdout.write(
-        convertDayColor(
-          current_date,
-          now,
-        ) + " ",
-      );
-    } else {
-      process.stdout.write(i.toString().padStart(2, " ") + " ");
-    }
+    process.stdout.write(formatDay(current_date, now) + " ");
 
     if (current_date.format("d") === "6") {
       process.stdout.write("\n");
@@ -65,11 +55,11 @@ function printCalendarBody(first_date, last_date, is_this_month, now) {
   if (last_date.format("d") !== "0") process.stdout.write("\n");
 }
 
-function convertDayColor(date, now) {
+function formatDay(date, now) {
   const day_str = date.date().toString().padStart(2, " ");
-  if (date.date() === now.date()) {
+  if (date.isSame(now, "date")) {
     return `\x1b[7m${day_str}\x1b[0m`;
-  } else {
-    return day_str;
   }
+
+  return day_str;
 }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import minimist from "minimist";
+import dayjs from "dayjs";
+import isToday from "dayjs/plugin/isToday.js";
+
+main();
+
+function main() {
+  dayjs().locale("ja");
+
+  const options = minimist(process.argv.slice(2));
+
+  if (options.y && !options.m) {
+    console.error("y オプションのみは対応していません");
+    process.exit(1);
+  }
+
+  const specified_date = dayjs()
+    .month((options.m || dayjs().format("M")) - 1)
+    .year(options.y || dayjs().format("YYYY"));
+
+  printCalendarHeader(
+    specified_date.format("M"),
+    specified_date.format("YYYY"),
+  );
+
+  printCalendarBody(
+    specified_date.startOf("M"),
+    specified_date.endOf("M"),
+    specified_date.format("YYYY") === dayjs().format("YYYY") &&
+      specified_date.format("M") === dayjs().format("M"),
+  );
+}
+
+function printCalendarHeader(month, year) {
+  console.log(`      ${month}月 ${year}`);
+  console.log(`日 月 火 水 木 金 土`);
+}
+
+function printCalendarBody(first_date, last_date, is_this_month) {
+  for (let i = 0; i < Number(first_date.format("d")); i++) {
+    process.stdout.write("   ");
+  }
+
+  for (let i = 1; i <= Number(last_date.format("D")); i++) {
+    const current_date = first_date.date(i);
+
+    if (is_this_month) {
+      process.stdout.write(
+        convertDayColor(
+          current_date.format("YYYY"),
+          current_date.format("M"),
+          i,
+        ) + " ",
+      );
+    } else {
+      process.stdout.write(i.toString().padStart(2, " ") + " ");
+    }
+
+    if (current_date.format("d") === "6") {
+      process.stdout.write("\n");
+    }
+  }
+
+  process.stdout.write("\n");
+  if (last_date.format("d") !== "0") process.stdout.write("\n");
+}
+
+function convertDayColor(year, month, day) {
+  dayjs.extend(isToday);
+  const date = dayjs(new Date(year, Number(month) - 1, day));
+  const day_str = day.toString().padStart(2, " ");
+  if (date.isToday()) {
+    return `\x1b[7m${day_str}\x1b[0m`;
+  } else {
+    return day_str;
+  }
+}

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -2,12 +2,11 @@
 
 import minimist from "minimist";
 import dayjs from "dayjs";
-import isToday from "dayjs/plugin/isToday.js";
 
 main();
 
 function main() {
-  dayjs().locale("ja");
+  const now = dayjs().locale("ja");
 
   const options = minimist(process.argv.slice(2));
 
@@ -16,9 +15,9 @@ function main() {
     process.exit(1);
   }
 
-  const specified_date = dayjs()
-    .month((options.m || dayjs().format("M")) - 1)
-    .year(options.y || dayjs().format("YYYY"));
+  const specified_date = now
+    .month((options.m || now.format("M")) - 1)
+    .year(options.y || now.format("YYYY"));
 
   printCalendarHeader(
     specified_date.format("M"),
@@ -28,8 +27,9 @@ function main() {
   printCalendarBody(
     specified_date.startOf("M"),
     specified_date.endOf("M"),
-    specified_date.format("YYYY") === dayjs().format("YYYY") &&
-      specified_date.format("M") === dayjs().format("M"),
+    specified_date.format("YYYY") === now.format("YYYY") &&
+      specified_date.format("M") === now.format("M"),
+    now,
   );
 }
 
@@ -38,7 +38,7 @@ function printCalendarHeader(month, year) {
   console.log(`日 月 火 水 木 金 土`);
 }
 
-function printCalendarBody(first_date, last_date, is_this_month) {
+function printCalendarBody(first_date, last_date, is_this_month, now) {
   for (let i = 0; i < Number(first_date.format("d")); i++) {
     process.stdout.write("   ");
   }
@@ -52,6 +52,7 @@ function printCalendarBody(first_date, last_date, is_this_month) {
           current_date.format("YYYY"),
           current_date.format("M"),
           i,
+          now,
         ) + " ",
       );
     } else {
@@ -67,11 +68,10 @@ function printCalendarBody(first_date, last_date, is_this_month) {
   if (last_date.format("d") !== "0") process.stdout.write("\n");
 }
 
-function convertDayColor(year, month, day) {
-  dayjs.extend(isToday);
+function convertDayColor(year, month, day, now) {
   const date = dayjs(new Date(year, Number(month) - 1, day));
   const day_str = day.toString().padStart(2, " ");
-  if (date.isToday()) {
+  if (date.date() === now.date()) {
     return `\x1b[7m${day_str}\x1b[0m`;
   } else {
     return day_str;

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -48,9 +48,7 @@ function printCalendarBody(first_date, last_date, is_this_month, now) {
     if (is_this_month) {
       process.stdout.write(
         convertDayColor(
-          current_date.format("YYYY"),
-          current_date.format("M"),
-          i,
+          current_date,
           now,
         ) + " ",
       );
@@ -67,9 +65,8 @@ function printCalendarBody(first_date, last_date, is_this_month, now) {
   if (last_date.format("d") !== "0") process.stdout.write("\n");
 }
 
-function convertDayColor(year, month, day, now) {
-  const date = dayjs(new Date(year, Number(month) - 1, day));
-  const day_str = day.toString().padStart(2, " ");
+function convertDayColor(date, now) {
+  const day_str = date.date().toString().padStart(2, " ");
   if (date.date() === now.date()) {
     return `\x1b[7m${day_str}\x1b[0m`;
   } else {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -27,8 +27,7 @@ function main() {
   printCalendarBody(
     specified_date.startOf("M"),
     specified_date.endOf("M"),
-    specified_date.format("YYYY") === now.format("YYYY") &&
-      specified_date.format("M") === now.format("M"),
+    specified_date.isSame(now, "month"),
     now,
   );
 }

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -4,6 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "dayjs": "^1.11.13",
+        "minimist": "^1.2.8"
+      },
       "devDependencies": {
         "@eslint/js": "^9.16.0",
         "eslint": "^9.16.0",
@@ -368,6 +372,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -844,6 +854,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -10,5 +10,9 @@
     "globals": "^15.13.0",
     "prettier": "^3.4.2"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "dayjs": "^1.11.13",
+    "minimist": "^1.2.8"
+  }
 }


### PR DESCRIPTION
## やったこと

```sh
cd 02.calendar
npm i
./cal.js
```
で `cal` コマンドと同じくカレンダーを表示できるようにした

## 確認してほしいこと

```sh
cd 02.calendar
npm i
./cal.js
```
* 上記でカレンダーが表示できること
* `./cal.js -m 9` で月を指定できること
* `./cal.js -m 9 -y 2020` で年を指定できること